### PR TITLE
Logging Revamp + Bug Fixes

### DIFF
--- a/ansible/roles/oso_analytics/defaults/main.yml
+++ b/ansible/roles/oso_analytics/defaults/main.yml
@@ -13,7 +13,7 @@ osoan_local_endpoint_enabled: false
 osoan_user_key_strategy: name
 osoan_woopra_endpoint: http://www.woopra.com/track/ce
 osoan_woopra_enabled: true
-osoan_log_level: 0
+osoan_log_level: info
 
 # If true, will completely uninstall app before running rest of role:
 osoan_uninstall: False

--- a/ansible/roles/oso_analytics/files/analytics-template.yaml
+++ b/ansible/roles/oso_analytics/files/analytics-template.yaml
@@ -64,7 +64,7 @@ parameters:
 
 - name: LOG_LEVEL
   description: Logging level.
-  value: "0"
+  value: "info"
 
 - name: LIVENESS_PROBE_PERIOD
   description: Liveness probe period in seconds.
@@ -284,5 +284,5 @@ objects:
           - -collectWoopra=$(METRICS_COLLECT_WOOPRA)
           - -collectQueue=$(METRICS_COLLECT_QUEUE)
           - -metricsBindAddr=:8080
-          - -v=$(LOG_LEVEL)
+          - -logLevel=$(LOG_LEVEL)
           - -logtostderr=true

--- a/ansible/vars/analytics_vars.yml
+++ b/ansible/vars/analytics_vars.yml
@@ -1,6 +1,10 @@
 # By default we use a mock local endpoint instead of connecting to Woopra:
 online_analytics_woopra_enabled: false
 online_analytics_local_endpoint_enabled: true
-online_analytics_log_level: 5
+online_analytics_log_level: debug
 
 osoan_cluster_name: devenv
+
+osoan_log_level: debug
+osoan_git_repo: "https://github.com/dgoodwin/online-analytics.git"
+osoan_git_ref: "logging-revamp"

--- a/cmd/user-analytics/cmd.go
+++ b/cmd/user-analytics/cmd.go
@@ -55,7 +55,8 @@ func main() {
 		log.SetLevel(lvl)
 	}
 
-	_, _, openshiftClient, kubeClient, err := createClients()
+	_, clientFac, openshiftClient, kubeClient, err := createClients()
+	_, typer := clientFac.Object()
 
 	if !validateKeyStrategy(userKeyStrategy) {
 		log.Fatalf("Must set a valid userKeyStrategy.")
@@ -73,6 +74,7 @@ func main() {
 		ClusterName:             clusterName,
 		UserKeyStrategy:         userKeyStrategy,
 		UserKeyAnnotation:       userKeyAnnotation,
+		Typer:                   typer,
 	}
 
 	if woopraEnabled {

--- a/pkg/useranalytics/analytics_controller.go
+++ b/pkg/useranalytics/analytics_controller.go
@@ -54,6 +54,7 @@ type AnalyticsController struct {
 	clusterName             string
 	userKeyStrategy         string
 	userKeyAnnotation       string
+	typer                   runtime.ObjectTyper
 }
 
 type AnalyticsControllerConfig struct {
@@ -65,6 +66,7 @@ type AnalyticsControllerConfig struct {
 	ClusterName             string
 	UserKeyStrategy         string
 	UserKeyAnnotation       string
+	Typer                   runtime.ObjectTyper
 }
 
 // NewAnalyticsController creates a new ThirdPartyAnalyticsController
@@ -86,6 +88,7 @@ func NewAnalyticsController(config *AnalyticsControllerConfig) (*AnalyticsContro
 		clusterName:             config.ClusterName,
 		userKeyStrategy:         config.UserKeyStrategy,
 		userKeyAnnotation:       config.UserKeyAnnotation,
+		typer:                   config.Typer,
 	}
 
 	return ctrl, nil
@@ -210,7 +213,7 @@ func (c *AnalyticsController) runWatches() {
 						c.watchResourceVersions[n] = m.GetResourceVersion()
 						c.mutex.Unlock()
 
-						analytic, err := newEvent(event.Object, event.Type)
+						analytic, err := newEvent(c.typer, event.Object, event.Type)
 						if err != nil {
 							watchLog.Errorf("unexpected error creating analytic from watch event %#v", event.Object)
 						} else {

--- a/pkg/useranalytics/analytics_controller_test.go
+++ b/pkg/useranalytics/analytics_controller_test.go
@@ -25,7 +25,7 @@ func TestAnalyticObjectCreation(t *testing.T) {
 		},
 	}
 
-	ev, err := newEvent(pod, watch.Added)
+	ev, err := newEvent(api.Scheme, pod, watch.Added)
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
@@ -38,7 +38,7 @@ func TestAnalyticObjectCreation(t *testing.T) {
 	}
 
 	pod.DeletionTimestamp = &metav1.Time{time.Now().Add(10 * time.Second)}
-	ev, err = newEvent(pod, watch.Deleted)
+	ev, err = newEvent(api.Scheme, pod, watch.Deleted)
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
@@ -50,7 +50,7 @@ func TestAnalyticObjectCreation(t *testing.T) {
 		t.Errorf("Expected %v but got %v", pod.DeletionTimestamp.UnixNano(), ev.timestamp.UnixNano())
 	}
 
-	ev, err = newEvent(pod, watch.Modified)
+	ev, err = newEvent(api.Scheme, pod, watch.Modified)
 	if err == nil {
 		t.Errorf("Expected error but got nil")
 	}
@@ -131,7 +131,7 @@ func TestGetUserId(t *testing.T) {
 		pod.Name = "foo"
 		pod.Namespace = "foo"
 
-		event, _ := newEvent(pod, watch.Added)
+		event, _ := newEvent(api.Scheme, pod, watch.Added)
 		// this is added by AddEvent, which puts many analyticEvents in the queue, one for each destination
 		event.destination = "mock"
 

--- a/pkg/useranalytics/destinations_test.go
+++ b/pkg/useranalytics/destinations_test.go
@@ -22,7 +22,7 @@ func TestWoopraDestination(t *testing.T) {
 
 	// TODO:  this needs some kind of factory per object
 	// that creates analyticsEvent objects
-	event, _ := newEvent(pod, watch.Added)
+	event, _ := newEvent(api.Scheme, pod, watch.Added)
 
 	dest := &WoopraDestination{
 		Method:   "GET",
@@ -58,7 +58,7 @@ func TestWoopraLive(t *testing.T) {
 		m.SetName("foo")
 		m.SetNamespace("foobar")
 
-		event, _ := newEvent(w.objType, watch.Added)
+		event, _ := newEvent(api.Scheme, w.objType, watch.Added)
 
 		dest := &WoopraDestination{
 			Method:   "GET",

--- a/pkg/useranalytics/metrics.go
+++ b/pkg/useranalytics/metrics.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/golang/glog"
+	log "github.com/Sirupsen/logrus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
@@ -88,7 +88,7 @@ func (s *MetricsServer) Serve() error {
 type logWrapper struct{}
 
 func (l *logWrapper) Println(v ...interface{}) {
-	glog.V(0).Info(v)
+	log.Info(v)
 }
 
 type WoopraCollector struct {

--- a/pkg/useranalytics/testing.go
+++ b/pkg/useranalytics/testing.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/golang/glog"
+	log "github.com/Sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -83,7 +83,7 @@ func (m *MockHttpEndpoint) Run(stopCh <-chan struct{}) {
 
 	go wait.Until(m.serve, 1*time.Second, stopCh)
 	go wait.Until(m.log, 60*time.Second, stopCh)
-	glog.Info("Mock endpoint started")
+	log.Info("Mock endpoint started")
 }
 
 func (m *MockHttpEndpoint) log() {
@@ -91,11 +91,11 @@ func (m *MockHttpEndpoint) log() {
 }
 
 func (m *MockHttpEndpoint) serve() {
-	glog.V(1).Infof("Mock endpoint listening at %s", m.URLPrefix)
+	log.Infof("Mock endpoint listening at %s", m.URLPrefix)
 	http.HandleFunc("/", m.handler)
 	strPort := fmt.Sprintf(":%d", m.Port)
 	if err := http.ListenAndServe(strPort, nil); err != nil {
-		glog.Fatal("Could not start server")
+		log.Fatal("Could not start server")
 	}
 }
 
@@ -115,7 +115,7 @@ func (m *MockHttpEndpoint) handler(w http.ResponseWriter, r *http.Request) {
 
 	hash := fmt.Sprintf("%s, %s, %s, %s, %s, %s, %s, %s", host, event, cv_email, cv_project_namespace, ce_name, ce_namespace, ce_uid, ce_timestamp)
 
-	glog.V(5).Infof("MockEndpoint received %v", hash)
+	log.Infof("MockEndpoint received %v", hash)
 
 	if m.DupeCheck {
 		if _, exists := m.Analytics[hash]; !exists {

--- a/pkg/useranalytics/types_test.go
+++ b/pkg/useranalytics/types_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestHash(t *testing.T) {
+	typer := api.Scheme
 
 	hashedValues := make(map[string]bool)
 
@@ -58,7 +59,7 @@ func TestHash(t *testing.T) {
 			},
 		},
 	} {
-		event, err := newEvent(test.obj, watch.Added)
+		event, err := newEvent(typer, test.obj, watch.Added)
 		if err != nil {
 			t.Errorf("Unexpected error %s", err)
 		}
@@ -82,7 +83,7 @@ func TestAnalyticEventFactoryFuncs(t *testing.T) {
 			},
 			expected: &analyticsEvent{
 				objectKind:      "pod",
-				event:           "add",
+				event:           "pod_added",
 				objectName:      "foo",
 				objectNamespace: "bar",
 			},
@@ -96,7 +97,7 @@ func TestAnalyticEventFactoryFuncs(t *testing.T) {
 			},
 			expected: &analyticsEvent{
 				objectKind:      "replicationcontroller",
-				event:           "add",
+				event:           "replicationcontroller_added",
 				objectName:      "foo",
 				objectNamespace: "bar",
 			},
@@ -110,7 +111,7 @@ func TestAnalyticEventFactoryFuncs(t *testing.T) {
 			},
 			expected: &analyticsEvent{
 				objectKind:      "persistentvolumeclaim",
-				event:           "add",
+				event:           "persistentvolumeclaim_added",
 				objectName:      "foo",
 				objectNamespace: "bar",
 			},
@@ -124,7 +125,7 @@ func TestAnalyticEventFactoryFuncs(t *testing.T) {
 			},
 			expected: &analyticsEvent{
 				objectKind:      "secret",
-				event:           "add",
+				event:           "secret_added",
 				objectName:      "foo",
 				objectNamespace: "bar",
 			},
@@ -138,7 +139,7 @@ func TestAnalyticEventFactoryFuncs(t *testing.T) {
 			},
 			expected: &analyticsEvent{
 				objectKind:      "service",
-				event:           "add",
+				event:           "service_added",
 				objectName:      "foo",
 				objectNamespace: "bar",
 			},
@@ -152,7 +153,7 @@ func TestAnalyticEventFactoryFuncs(t *testing.T) {
 			},
 			expected: &analyticsEvent{
 				objectKind:      "namespace",
-				event:           "add",
+				event:           "namespace_added",
 				objectName:      "foo",
 				objectNamespace: "bar",
 			},
@@ -166,7 +167,7 @@ func TestAnalyticEventFactoryFuncs(t *testing.T) {
 			},
 			expected: &analyticsEvent{
 				objectKind:      "deployment",
-				event:           "add",
+				event:           "deploymentconfig_added",
 				objectName:      "foo",
 				objectNamespace: "bar",
 			},
@@ -180,7 +181,7 @@ func TestAnalyticEventFactoryFuncs(t *testing.T) {
 			},
 			expected: &analyticsEvent{
 				objectKind:      "route",
-				event:           "add",
+				event:           "route_added",
 				objectName:      "foo",
 				objectNamespace: "bar",
 			},
@@ -194,7 +195,7 @@ func TestAnalyticEventFactoryFuncs(t *testing.T) {
 			},
 			expected: &analyticsEvent{
 				objectKind:      "build",
-				event:           "add",
+				event:           "build_added",
 				objectName:      "foo",
 				objectNamespace: "bar",
 			},
@@ -222,7 +223,7 @@ func TestAnalyticEventFactoryFuncs(t *testing.T) {
 			},
 			expected: &analyticsEvent{
 				objectKind:      "template",
-				event:           "add",
+				event:           "template_added",
 				objectName:      "foo",
 				objectNamespace: "bar",
 			},
@@ -236,7 +237,7 @@ func TestAnalyticEventFactoryFuncs(t *testing.T) {
 			},
 			expected: &analyticsEvent{
 				objectKind:      "imagestream",
-				event:           "add",
+				event:           "imagestream_added",
 				objectName:      "foo",
 				objectNamespace: "bar",
 			},
@@ -244,7 +245,13 @@ func TestAnalyticEventFactoryFuncs(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		event, _ := newEvent(test.input, watch.Added)
+		event, err := newEvent(api.Scheme, test.input, watch.Added)
+		if err != nil {
+			t.Errorf("Test %s got unexpected error: %v", name, err)
+		}
+		if event.event != test.expected.event {
+			t.Errorf("Test %s expected event '%s' but got '%s'", name, test.expected.event, event.event)
+		}
 		if event.objectName != test.expected.objectName {
 			t.Errorf("Expected %s but got %s", test.expected.objectName, event.objectName)
 		}

--- a/test/analytics_integration_test.go
+++ b/test/analytics_integration_test.go
@@ -66,6 +66,7 @@ func TestProvisioner(t *testing.T) {
 		MaximumQueueLength:      10000,
 		MetricsPollingFrequency: 5,
 		UserKeyStrategy:         "uid",
+		Typer:                   api.Scheme,
 	}
 
 	config.Destinations["mock"] = &useranalytics.WoopraDestination{


### PR DESCRIPTION
Two separate commits each with details in commit message here.

TL;DR: 

Revamps logging to get a better picture of what the application is doing. Switched to logrus for structured logging (readability, parsing, and hopefully future importing into our openshift logging stack) and use of error->warning->info->debug loglevels. At info this change aims to log one line per successful analytic event. If this proves to be too much we can move to warn or error. 

Warnings will now be logged for a previously uncaught situation where Woopra responds with a non-200 HTTP status. If this proves too verbose we can go to error level. This surfaced in testing so we may be losing analytics silently in the wild.

Fixed a bug resulting from the origin 3.7 vendoring where analytics show up with names like *v1.buildconfig_added, rather than buildconfig_added.