### PR TITLE
Improve Ansible idempotency.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 ansible/roles/lib_openshift
+ansible/roles/oc_start_build_check
+ansible/vars/zz_custom_vars.yml
+ansible/*.retry
 ansible.log
 ansible/.gogitit-cache.yml

--- a/ansible/gogitit.yml
+++ b/ansible/gogitit.yml
@@ -8,3 +8,9 @@ repos:
   copy:
   - src: roles/lib_openshift/
     dst: roles/lib_openshift/
+- id: online-archivist
+  url: https://github.com/openshift/online-archivist.git
+  version: master
+  copy:
+  - src: ansible/roles/oc_start_build_check/
+    dst: roles/oc_start_build_check/

--- a/ansible/roles/oso_analytics/README.md
+++ b/ansible/roles/oso_analytics/README.md
@@ -5,6 +5,7 @@ A role to deploy and configure the OpenShift Online User Analytics application.
 ## Dependencies
 
 - lib_openshift role from openshift-ansible must be loaded in a playbook prior to running this role.
+- oc_start_build_check role from online-archivist repository. (included via gogitit)
 
 ## Role Variables
 

--- a/ansible/roles/oso_analytics/files/analytics-template.yaml
+++ b/ansible/roles/oso_analytics/files/analytics-template.yaml
@@ -27,10 +27,6 @@ parameters:
   description: The number of seconds between metrics snapshots.
   value: "10"
 
-- name: METRICS_PORT
-  description: Port to create a service for http metrics requests
-  value: "8080"
-
 - name: METRICS_COLLECT_RUNTIME
   description: Enable runtime metrics
   value: "true"
@@ -65,14 +61,6 @@ parameters:
 - name: LOG_LEVEL
   description: Logging level.
   value: "info"
-
-- name: LIVENESS_PROBE_PERIOD
-  description: Liveness probe period in seconds.
-  value: "10"
-
-- name: READINESS_PROBE_PERIOD
-  description: Readiness probe period in seconds.
-  value: "10"
 
 - name: CPU_REQUEST
   description: CPU resource request
@@ -143,7 +131,7 @@ objects:
     ports:
     - name: "metrics"
       protocol: TCP
-      port: ${METRICS_PORT}
+      port: 8080
       targetPort: "metrics"
 
 # Binds the service account to the account management role
@@ -222,14 +210,14 @@ objects:
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 5
-            periodSeconds: ${LIVENESS_PROBE_PERIOD}
+            periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /healthz/ready
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 5
-            periodSeconds: ${READINESS_PROBE_PERIOD}
+            periodSeconds: 10
           ports:
           - name: "metrics"
             containerPort: 8080

--- a/ansible/roles/oso_analytics/tasks/main.yml
+++ b/ansible/roles/oso_analytics/tasks/main.yml
@@ -17,7 +17,8 @@
 # Because this app is stateless in the cluster, no data should be lost here, we just
 # resume submitting to Woopra.
 # TODO: this can be removed once this role has run against all environments
-- name: "uninstall legacy components"
+# TODO: why does this always show a change?
+- name: Uninstall legacy components
   oc_obj:
     state: absent
     kind: "{{ item.kind }}"
@@ -28,13 +29,13 @@
 
 - debug: msg="Deploying {{ osoan_name}} from {{ osoan_git_repo }} ref {{osoan_git_ref }}"
 
-- name: copy application template
+- name: Copy application template
   copy:
     src: analytics-template.yaml
     dest: "{{ osoan_template_path }}"
     #  register: copy_template_out
 
-- name: create template
+- name: Create template
   oc_obj:
     state: present
     namespace: "{{ osoan_namespace }}"
@@ -43,19 +44,37 @@
     files:
     - "{{ osoan_template_path }}"
 
-- name: Create the analytics app using the analytics template
-  oc_process:
+- name: Apply template
+  shell: "oc process -n {{ osoan_namespace }} user-analytics -p GIT_REPO='{{ osoan_git_repo }}' -p GIT_REF='{{ osoan_git_ref }}' -p WOOPRA_ENABLED='{{ osoan_woopra_enabled }}' -p WOOPRA_ENDPOINT='{{ osoan_woopra_endpoint }}' -p WOOPRA_DOMAIN='{{ osoan_woopra_domain }}' -p LOCAL_ENDPOINT_ENABLED='{{ osoan_local_endpoint_enabled }}' -p USER_KEY_STRATEGY='{{ osoan_user_key_strategy }}' -p CLUSTER_NAME='{{ osoan_cluster_name }}' -p LOG_LEVEL='{{ osoan_log_level }}' | oc apply -n {{ osoan_namespace }} -f -"
+  # apply does not indicate if something changed today. Assume changed_when
+  # false and rely on the template update as our best indicator if something
+  # changed.
+  changed_when: false
+
+- name: Fetch latest git commit
+  git:
+    repo: "{{ osoan_git_repo }}"
+    version: "{{ osoan_git_ref }}"
+    clone: no
+    accept_hostkey: true
+  register: git_sha1_results
+  # Git may not be installed on remote hosts.
+  delegate_to: localhost
+  changed_when: false
+
+- debug: msg="Checking that latest build matches git ref {{ git_sha1_results.after }}"
+
+- name: Load the start-build role so module is available
+  include_role:
+    name: oc_start_build_check
+
+- name: Start build if required
+  oc_start_build_check:
     namespace: "{{ osoan_namespace }}"
-    template_name: user-analytics
-    create: True
-    reconcile: True
-    params:
-      GIT_REPO: "{{ osoan_git_repo }}"
-      GIT_REF: "{{ osoan_git_ref }}"
-      WOOPRA_ENABLED: "{{ osoan_woopra_enabled }}"
-      WOOPRA_ENDPOINT: "{{ osoan_woopra_endpoint }}"
-      WOOPRA_DOMAIN: "{{ osoan_woopra_domain }}"
-      LOCAL_ENDPOINT_ENABLED: "{{ osoan_local_endpoint_enabled }}"
-      USER_KEY_STRATEGY: "{{ osoan_user_key_strategy }}"
-      CLUSTER_NAME: "{{ osoan_cluster_name }}"
-      LOG_LEVEL: "{{ osoan_log_level }}"
+    buildconfig: "analytics"
+    git_ref: "{{ git_sha1_results.after }}"
+  register: start_build_out
+
+- debug: var=start_build_out
+
+

--- a/ansible/vars/analytics_vars.yml
+++ b/ansible/vars/analytics_vars.yml
@@ -6,5 +6,5 @@ online_analytics_log_level: debug
 osoan_cluster_name: devenv
 
 osoan_log_level: debug
-osoan_git_repo: "https://github.com/dgoodwin/online-analytics.git"
-osoan_git_ref: "logging-revamp"
+osoan_git_repo: "https://github.com/openshift/online-analytics.git"
+osoan_git_ref: master


### PR DESCRIPTION
Similar to what we just merged for archivist, the role to deploy the app
will no longer destroy the running app and trigger a build. Instead we
maintain the OpenShift objects, update them if necessary, and check if a
start-build is required on each run.

Several parameters in the template which user integers now fail to
process citing a "int32" error, this surfaces because we switch to direct use of oc process, the lib_openshift module used before doesn't actually do an oc process per se. Suspect related to:
https://github.com/openshift/origin/issues/3946. These parameters were
never customized so to work around they have been removed and just hard
coded. We can update the template and re-run ansible to adjust in
future, which would be required even to reprocess the template.