### PR TITLE
ansible use osoan_name throughout

### DIFF
--- a/ansible/roles/oso_analytics/defaults/main.yml
+++ b/ansible/roles/oso_analytics/defaults/main.yml
@@ -7,7 +7,7 @@ osoan_git_repo: "https://github.com/openshift/online-analytics.git"
 osoan_git_ref: "master"
 
 osoan_template_path: /etc/openshift-online/templates/analytics.yaml
-osoan_name: analytics
+osoan_name: user-analytics
 osoan_namespace: openshift-infra
 osoan_local_endpoint_enabled: false
 osoan_user_key_strategy: name

--- a/ansible/roles/oso_analytics/tasks/main.yml
+++ b/ansible/roles/oso_analytics/tasks/main.yml
@@ -15,8 +15,8 @@
     msg: "Deploying {{ osoan_name}} from {{ osoan_git_repo }} ref {{osoan_git_ref }}"
 
 - name: Copy application template
-  copy:
-    src: analytics-template.yaml
+  template:
+    src: analytics-template.yaml.j2
     dest: "{{ osoan_template_path }}"
   register: template
 
@@ -59,7 +59,7 @@
 - name: Start build if required
   oc_start_build_check:
     namespace: "{{ osoan_namespace }}"
-    buildconfig: "analytics"
+    buildconfig: "{{ osoan_name }}"
     git_ref: "{{ git_sha1_results.after }}"
   register: start_build_out
 

--- a/ansible/roles/oso_analytics/templates/analytics-template.yaml.j2
+++ b/ansible/roles/oso_analytics/templates/analytics-template.yaml.j2
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: user-analytics
+  name: "{{ osoan_name }}"
 parameters:
 - name: NAME
   description: The name of the DeploymentConfig.
-  value: analytics
+  value: "{{ osoan_name }}"
 
 - name: GIT_REPO
   description: Git repository housing the Analytics Dockerfile and application code to build and deploy.
@@ -85,7 +85,7 @@ objects:
   metadata:
     annotations:
       authorization.openshift.io/system-only: "true"
-    name: user-analytics
+    name: ${NAME}
   rules:
   - resources:
     - pods
@@ -120,13 +120,13 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
-    name: user-analytics
+    name: ${NAME}
 
 # A service to expose the metrics server
 - apiVersion: v1
   kind: Service
   metadata:
-    name: user-analytics
+    name: ${NAME}
   spec:
     ports:
     - name: "metrics"
@@ -138,12 +138,12 @@ objects:
 - apiVersion: v1
   kind: ClusterRoleBinding
   metadata:
-    name: user-analytics
+    name: ${NAME}
   roleRef:
-    name: user-analytics
+    name: ${NAME}
   subjects:
   - kind: ServiceAccount
-    name: user-analytics
+    name: ${NAME}
     namespace: openshift-infra
 
 - apiVersion: v1
@@ -200,7 +200,7 @@ objects:
         labels:
           app: ${NAME}
       spec:
-        serviceAccountName: user-analytics
+        serviceAccountName: ${NAME}
         containers:
         - name: ${NAME}
           image: ${NAME}


### PR DESCRIPTION
@dak1n1 some places in the role were using 'analytics' others 'user-analytics' for name parameter.   I've followed suit with our other roles and made all  "{{ osoan_name }}" .  I've put `osoan_name: user-analytics` in the defaults, but we can change that to whatever you're using currently in Ops.  

The role was error-ing out for me in a devenv bc of the mismatch in names.
