### PR TITLE
remove template file when running uninstall

### DIFF
--- a/ansible/roles/oso_analytics/tasks/main.yml
+++ b/ansible/roles/oso_analytics/tasks/main.yml
@@ -8,7 +8,7 @@
   - osoan_woopra_enabled
   - osoan_woopra_domain
 
-- include: uninstall.yml
+- import_tasks: uninstall.yml
   when: osoan_uninstall | bool
 
 - debug:

--- a/ansible/roles/oso_analytics/tasks/uninstall.yml
+++ b/ansible/roles/oso_analytics/tasks/uninstall.yml
@@ -13,3 +13,7 @@
     - { kind: "clusterrole", name: "{{ osoan_name }}" }
     - { kind: "serviceaccount", name: "{{ osoan_name }}" }
     - { kind: "service", name: "{{ osoan_name }}" }
+- name: "remove {{ osoan_template_path }}"
+  file:
+    path: "{{ osoan_template_path }}"
+    state: absent


### PR DESCRIPTION
When uninstalling, have to remove the template file.  Otherwise, the template|changed doesn't register.