### PR TITLE
ansible ensure template directory exists

### DIFF
--- a/ansible/roles/oso_analytics/defaults/main.yml
+++ b/ansible/roles/oso_analytics/defaults/main.yml
@@ -6,7 +6,8 @@
 osoan_git_repo: "https://github.com/openshift/online-analytics.git"
 osoan_git_ref: "master"
 
-osoan_template_path: /etc/openshift-online/templates/analytics.yaml
+osoan_template_directory: /etc/openshift-online/templates
+osoan_template_path: "{{ osoan_template_directory }}/analytics.yaml"
 osoan_name: user-analytics
 osoan_namespace: openshift-infra
 osoan_local_endpoint_enabled: false

--- a/ansible/roles/oso_analytics/tasks/main.yml
+++ b/ansible/roles/oso_analytics/tasks/main.yml
@@ -14,6 +14,12 @@
 - debug:
     msg: "Deploying {{ osoan_name}} from {{ osoan_git_repo }} ref {{osoan_git_ref }}"
 
+# Keep the same file structure as we currently have with openshift-scripts rpm
+- name: Ensure template directory exists
+  file:
+    path: "{{ osoan_template_directory }}"
+    state: directory
+
 - name: Copy application template
   template:
     src: analytics-template.yaml.j2


### PR DESCRIPTION
@dak1n1 @abhgupta I notice while testing this role, if the template dir doesn't exist it fails.  Currently, the openshift-scripts rpm creates this directory, but if/when the openshift-scripts rpm is replaced with ansible, we'll need to ensure the template directory exists.